### PR TITLE
URL Cleanup

### DIFF
--- a/CODE_OF_CONDUCT.adoc
+++ b/CODE_OF_CONDUCT.adoc
@@ -40,5 +40,5 @@ appropriate to the circumstances. Maintainers are obligated to maintain confiden
 with regard to the reporter of an incident.
 
 This Code of Conduct is adapted from the
-http://contributor-covenant.org[Contributor Covenant], version 1.3.0, available at
-http://contributor-covenant.org/version/1/3/0/[contributor-covenant.org/version/1/3/0/]
+https://contributor-covenant.org[Contributor Covenant], version 1.3.0, available at
+https://contributor-covenant.org/version/1/3/0/[contributor-covenant.org/version/1/3/0/]

--- a/spring-cloud-starter-stream-common-tensorflow/src/main/java/org/springframework/cloud/stream/app/tensorflow/processor/TensorflowInputConverter.java
+++ b/spring-cloud-starter-stream-common-tensorflow/src/main/java/org/springframework/cloud/stream/app/tensorflow/processor/TensorflowInputConverter.java
@@ -28,7 +28,7 @@ import java.util.Map;
  * is encoded into key/value Map or flat key/value JSON message. Where each key in the map corresponds to a model input
  * placeholder and the value is compliant with TensorFlow's {@link org.tensorflow.DataType}.
  *
- *  @see <a href="http://bit.ly/2ox4IFG">TwitterSentimentTensorflowInputConverter.java</a> for how to build custom {@link TensorflowInputConverter}.
+ *  @see <a href="https://bit.ly/2ox4IFG">TwitterSentimentTensorflowInputConverter.java</a> for how to build custom {@link TensorflowInputConverter}.
  *
  * @author Christian Tzolov
  */

--- a/spring-cloud-starter-stream-common-tensorflow/src/main/java/org/springframework/cloud/stream/app/tensorflow/util/ModelExtractor.java
+++ b/spring-cloud-starter-stream-common-tensorflow/src/main/java/org/springframework/cloud/stream/app/tensorflow/util/ModelExtractor.java
@@ -38,7 +38,7 @@ import org.springframework.util.StringUtils;
  * URI schemas are supported.
  *
  * Models can be extract either from raw files or form compressed archives. When  extracted from an archive the model
- * file name can optionally be provided as an URI fragment. For example for resource: http://myarchive.tar.gz#model.pb
+ * file name can optionally be provided as an URI fragment. For example for resource: https://myarchive.tar.gz#model.pb
  * the myarchive.tar.gz is traversed to uncompress and extract the model.pb file as byte array.
  * If the file name is not provided as URI fragment then the first file in the archive with extension .pb is extracted.
  *

--- a/spring-cloud-starter-stream-processor-image-recognition/src/main/resources/config/application.yml
+++ b/spring-cloud-starter-stream-processor-image-recognition/src/main/resources/config/application.yml
@@ -1,8 +1,8 @@
 tensorflow:
   modelFetch: output
-  model: http://dl.bintray.com/big-data/generic/tensorflow_inception_graph.pb
+  model: https://dl.bintray.com/big-data/generic/tensorflow_inception_graph.pb
   image:
     recognition:
-      labels: http://dl.bintray.com/big-data/generic/imagenet_comp_graph_label_strings.txt
+      labels: https://dl.bintray.com/big-data/generic/imagenet_comp_graph_label_strings.txt
       responseSize: 3
       drawLabels: true

--- a/spring-cloud-starter-stream-processor-image-recognition/src/test/java/org/springframework/cloud/stream/app/image/recognition/processor/inception/ImageRecognitionTensorflowProcessorIntegrationTests.java
+++ b/spring-cloud-starter-stream-processor-image-recognition/src/test/java/org/springframework/cloud/stream/app/image/recognition/processor/inception/ImageRecognitionTensorflowProcessorIntegrationTests.java
@@ -52,9 +52,9 @@ import static org.hamcrest.Matchers.equalTo;
 @SpringBootTest(
 		webEnvironment = SpringBootTest.WebEnvironment.NONE,
 		properties = {
-				"tensorflow.model=http://dl.bintray.com/big-data/generic/tensorflow_inception_graph.pb",
+				"tensorflow.model=https://dl.bintray.com/big-data/generic/tensorflow_inception_graph.pb",
 				"tensorflow.modelFetch=output",
-				"tensorflow.image.recognition.labels=http://dl.bintray.com/big-data/generic/imagenet_comp_graph_label_strings.txt"
+				"tensorflow.image.recognition.labels=https://dl.bintray.com/big-data/generic/imagenet_comp_graph_label_strings.txt"
 		})
 @DirtiesContext
 public abstract class ImageRecognitionTensorflowProcessorIntegrationTests {

--- a/spring-cloud-starter-stream-processor-object-detection/README.adoc
+++ b/spring-cloud-starter-stream-processor-object-detection/README.adoc
@@ -7,8 +7,8 @@ The new https://github.com/spring-cloud-stream-app-starters/tensorflow/tree/mast
 If the pre-trained model is not set explicitly set then following defaults are used:
 
 * `tensorflow.modelFetch` : `detection_scores,detection_classes,detection_boxes,num_detections`
-* `tensorflow.model` : `http://dl.bintray.com/big-data/generic/faster_rcnn_resnet101_coco_2018_01_28_frozen_inference_graph.pb`
-* `tensorflow.object.detection.labels` : `http://dl.bintray.com/big-data/generic/mscoco_label_map.pbtxt`
+* `tensorflow.model` : `https://dl.bintray.com/big-data/generic/faster_rcnn_resnet101_coco_2018_01_28_frozen_inference_graph.pb`
+* `tensorflow.object.detection.labels` : `https://dl.bintray.com/big-data/generic/mscoco_label_map.pbtxt`
 
 The following diagram illustrates a Spring Cloud Data Flow streaming pipeline that predicts object types from the images in real-time.
 
@@ -78,9 +78,9 @@ And here is a example pipeline that process images in `file` source and outputs 
 ```
 object-detector-stream=file --directory='/tmp/images'
 | object-detector --tensorflow.mode=header
-    --tensorflow.model='http://dl.bintray.com/big-data/generic/faster_rcnn_resnet101_coco_2018_01_28_frozen_inference_graph.pb'
+    --tensorflow.model='https://dl.bintray.com/big-data/generic/faster_rcnn_resnet101_coco_2018_01_28_frozen_inference_graph.pb'
     --tensorflow.model-fetch='detection_scores,detection_classes,detection_boxes'
-    --tensorflow.object.detection.labels='http://dl.bintray.com/big-data/generic/mscoco_label_map.pbtxt'
+    --tensorflow.object.detection.labels='https://dl.bintray.com/big-data/generic/mscoco_label_map.pbtxt'
 | image-viewer
 ```
 

--- a/spring-cloud-starter-stream-processor-object-detection/src/main/java/org/springframework/cloud/stream/app/object/detection/processor/ObjectDetectionTensorflowOutputConverter.java
+++ b/spring-cloud-starter-stream-processor-object-detection/src/main/java/org/springframework/cloud/stream/app/object/detection/processor/ObjectDetectionTensorflowOutputConverter.java
@@ -38,7 +38,7 @@ import org.springframework.util.StringUtils;
 
 /**
  * Converts the Tensorflow Object Detection result into {@link ObjectDetection} list.
- * The pre-trained Object Detection models (http://bit.ly/2osxMAY) produce 3 tensor outputs:
+ * The pre-trained Object Detection models (https://bit.ly/2osxMAY) produce 3 tensor outputs:
  *  (1) detection_classes - containing the ids of detected objects, (2) detection_scores - confidence probabilities of the
  *  detected object and (3) detection_boxes - the object bounding boxes withing the images.
  *

--- a/spring-cloud-starter-stream-processor-object-detection/src/main/resources/config/application.yml
+++ b/spring-cloud-starter-stream-processor-object-detection/src/main/resources/config/application.yml
@@ -1,6 +1,6 @@
 tensorflow:
   modelFetch: detection_scores,detection_classes,detection_boxes,num_detections
-  model: http://dl.bintray.com/big-data/generic/ssdlite_mobilenet_v2_coco_2018_05_09_frozen_inference_graph.pb
+  model: https://dl.bintray.com/big-data/generic/ssdlite_mobilenet_v2_coco_2018_05_09_frozen_inference_graph.pb
   object:
     detection:
-      labels: http://dl.bintray.com/big-data/generic/mscoco_label_map.pbtxt
+      labels: https://dl.bintray.com/big-data/generic/mscoco_label_map.pbtxt

--- a/spring-cloud-starter-stream-processor-object-detection/src/test/java/org/springframework/cloud/stream/app/object/detection/processor/detection/ObjectDetectionTensorflowProcessorIntegrationTests.java
+++ b/spring-cloud-starter-stream-processor-object-detection/src/test/java/org/springframework/cloud/stream/app/object/detection/processor/detection/ObjectDetectionTensorflowProcessorIntegrationTests.java
@@ -54,10 +54,10 @@ import org.springframework.util.StreamUtils;
 		properties = {
 				//"tensorflow.modelFetch=detection_scores,detection_classes,detection_boxes,detection_masks,num_detections",
 				"tensorflow.modelFetch=detection_scores,detection_classes,detection_boxes,num_detections",
-				//"tensorflow.model=http://dl.bintray.com/big-data/generic/faster_rcnn_resnet101_coco_2018_01_28_frozen_inference_graph.pb",
-				"tensorflow.model=http://dl.bintray.com/big-data/generic/ssdlite_mobilenet_v2_coco_2018_05_09_frozen_inference_graph.pb",
+				//"tensorflow.model=https://dl.bintray.com/big-data/generic/faster_rcnn_resnet101_coco_2018_01_28_frozen_inference_graph.pb",
+				"tensorflow.model=https://dl.bintray.com/big-data/generic/ssdlite_mobilenet_v2_coco_2018_05_09_frozen_inference_graph.pb",
 				//"tensorflow.model=file:/Users/ctzolov/Downloads/ssd_mobilenet_v2_coco_2018_03_29/frozen_inference_graph.pb",
-				"tensorflow.object.detection.labels=http://dl.bintray.com/big-data/generic/mscoco_label_map.pbtxt",
+				"tensorflow.object.detection.labels=https://dl.bintray.com/big-data/generic/mscoco_label_map.pbtxt",
 				//"tensorflow.model=file:/Users/ctzolov/Downloads/mask_rcnn_resnet101_atrous_coco_2018_01_28/frozen_inference_graph.pb"
 				//"tensorflow.model=file:/Users/ctzolov/Downloads/ssd_inception_v2_coco_2017_11_17/frozen_inference_graph.pb",
 				//"tensorflow.model=file:/Users/ctzolov/Downloads/faster_rcnn_inception_resnet_v2_atrous_lowproposals_oid_2018_01_28/frozen_inference_graph.pb",

--- a/spring-cloud-starter-stream-processor-pose-estimation/README.adoc
+++ b/spring-cloud-starter-stream-processor-pose-estimation/README.adoc
@@ -24,8 +24,8 @@ for selecting the right body parts and grouping them into poses are implemented 
 
 Use the `tensorflow.model` property to set the pre-trained Tensorflow model. Here are some options available out of the box:
 
-*  `http://dl.bintray.com/big-data/generic/2018-30-05-mobilenet_thin_graph_opt.pb` (default) - fast but less accurate
-*  `http://dl.bintray.com/big-data/generic/2018-05-14-cmu-graph_opt.pb` - accurate but slower
+*  `https://dl.bintray.com/big-data/generic/2018-30-05-mobilenet_thin_graph_opt.pb` (default) - fast but less accurate
+*  `https://dl.bintray.com/big-data/generic/2018-05-14-cmu-graph_opt.pb` - accurate but slower
 
 Processor's input is an image byte array and the output is a JSON message and optionally an image with annotated body poses.
 The output JSON format looks like:
@@ -101,7 +101,7 @@ And here is a example pipeline that process images in `file` source and outputs 
 
 ```
 pose-estimation-stream=in: file --directory='/tmp/images'
-| pose-estimation --tensorflow.mode=header --tensorflow.model='http://dl.bintray.com/big-data/generic/2018-05-14-cmu-graph_opt.pb'
+| pose-estimation --tensorflow.mode=header --tensorflow.model='https://dl.bintray.com/big-data/generic/2018-05-14-cmu-graph_opt.pb'
 | out: file --directory='/tmp/output' --name-expression='headers[file_name]'
 ```
 

--- a/spring-cloud-starter-stream-processor-pose-estimation/src/test/java/org/springframework/cloud/stream/app/pose/estimation/processor/PoseEstimationTensorflowProcessorIntegrationTests.java
+++ b/spring-cloud-starter-stream-processor-pose-estimation/src/test/java/org/springframework/cloud/stream/app/pose/estimation/processor/PoseEstimationTensorflowProcessorIntegrationTests.java
@@ -53,7 +53,7 @@ import org.springframework.util.StreamUtils;
 		properties = {
 				"tensorflow.modelFetch=Openpose/concat_stage7",
 				"tensorflow.model=https://dl.bintray.com/big-data/generic/2018-05-14-cmu-graph_opt.pb"
-				//"tensorflow.model=http://dl.bintray.com/big-data/generic/2018-30-05-mobilenet_thin_graph_opt.pb"
+				//"tensorflow.model=https://dl.bintray.com/big-data/generic/2018-30-05-mobilenet_thin_graph_opt.pb"
 		})
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 public abstract class PoseEstimationTensorflowProcessorIntegrationTests {
@@ -68,7 +68,7 @@ public abstract class PoseEstimationTensorflowProcessorIntegrationTests {
 			"tensorflow.mode=payload",
 			"tensorflow.pose.estimation.minBodyPartCount=5",
 			"tensorflow.pose.estimation.totalPafScoreThreshold=4.4",
-			//"tensorflow.model=http://dl.bintray.com/big-data/generic/2018-30-05-mobilenet_thin_graph_opt.pb"
+			//"tensorflow.model=https://dl.bintray.com/big-data/generic/2018-30-05-mobilenet_thin_graph_opt.pb"
 	})
 	public static class OutputInPayloadTests extends PoseEstimationTensorflowProcessorIntegrationTests {
 
@@ -92,7 +92,7 @@ public abstract class PoseEstimationTensorflowProcessorIntegrationTests {
 				"tensorflow.mode=header",
 				//"tensorflow.model=file:/Users/ctzolov/Dev/projects/tf-pose-estimation/models/graph/mobilenet_thin/graph_opt.pb",
 				//"tensorflow.model=file:/Users/ctzolov/Dev/projects/tf-pose-estimation/models/graph/cmu/graph_opt.pb",
-				"tensorflow.model=http://dl.bintray.com/big-data/generic/2018-05-14-cmu-graph_opt.pb",
+				"tensorflow.model=https://dl.bintray.com/big-data/generic/2018-05-14-cmu-graph_opt.pb",
 
 				"tensorflow.pose.estimation.debugVisualisationEnabled=true",
 				"tensorflow.pose.estimation.minBodyPartCount=5",

--- a/spring-cloud-starter-stream-processor-twitter-sentiment/README.adoc
+++ b/spring-cloud-starter-stream-processor-twitter-sentiment/README.adoc
@@ -80,8 +80,8 @@ using the pre-build `minimal_graph.proto` and `vocab.csv`:
 ```
 tweets=twitterstream --access-token-secret=xxx --access-token=xxx --consumer-secret=xxx --consumer-key=xxx \
 | filter --expression=#jsonPath(payload,'$.lang')=='en' \
-| twitter-sentimet --vocabulary='http://dl.bintray.com/big-data/generic/vocab.csv' \
-   --output-name=output/Softmax --model='http://dl.bintray.com/big-data/generic/minimal_graph.proto' \
+| twitter-sentimet --vocabulary='https://dl.bintray.com/big-data/generic/vocab.csv' \
+   --output-name=output/Softmax --model='https://dl.bintray.com/big-data/generic/minimal_graph.proto' \
    --model-fetch=output/Softmax \
 | log
 ```

--- a/spring-cloud-starter-stream-processor-twitter-sentiment/src/test/java/org/springframework/cloud/stream/app/twitter/sentiment/processor/twitter/TwitterSentimentTensorflowProcessorIntegrationTests.java
+++ b/spring-cloud-starter-stream-processor-twitter-sentiment/src/test/java/org/springframework/cloud/stream/app/twitter/sentiment/processor/twitter/TwitterSentimentTensorflowProcessorIntegrationTests.java
@@ -48,9 +48,9 @@ import static org.hamcrest.Matchers.equalTo;
 @SpringBootTest(
 		webEnvironment = SpringBootTest.WebEnvironment.NONE,
 		properties = {
-				"tensorflow.model=http://dl.bintray.com/big-data/generic/minimal_graph.proto",
+				"tensorflow.model=https://dl.bintray.com/big-data/generic/minimal_graph.proto",
 				"tensorflow.modelFetch=output/Softmax",
-				"tensorflow.twitter.vocabulary=http://dl.bintray.com/big-data/generic/vocab.csv"
+				"tensorflow.twitter.vocabulary=https://dl.bintray.com/big-data/generic/vocab.csv"
 		})
 @DirtiesContext
 public abstract class TwitterSentimentTensorflowProcessorIntegrationTests {


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* [ ] http://download.tensorflow.org/models/deeplabv3_mnv2_pascal_train_aug_2018_01_29.tar.gz (200) with 2 occurrences could not be migrated:  
   ([https](https://download.tensorflow.org/models/deeplabv3_mnv2_pascal_train_aug_2018_01_29.tar.gz) result SSLHandshakeException).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://myarchive.tar.gz (UnknownHostException) with 1 occurrences migrated to:  
  https://myarchive.tar.gz ([https](https://myarchive.tar.gz) result UnknownHostException).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://dl.bintray.com/big-data/generic/imagenet_comp_graph_label_strings.txt with 2 occurrences migrated to:  
  https://dl.bintray.com/big-data/generic/imagenet_comp_graph_label_strings.txt ([https](https://dl.bintray.com/big-data/generic/imagenet_comp_graph_label_strings.txt) result 200).
* [ ] http://dl.bintray.com/big-data/generic/mscoco_label_map.pbtxt with 4 occurrences migrated to:  
  https://dl.bintray.com/big-data/generic/mscoco_label_map.pbtxt ([https](https://dl.bintray.com/big-data/generic/mscoco_label_map.pbtxt) result 200).
* [ ] http://bit.ly/2osxMAY with 1 occurrences migrated to:  
  https://bit.ly/2osxMAY ([https](https://bit.ly/2osxMAY) result 301).
* [ ] http://bit.ly/2ox4IFG with 1 occurrences migrated to:  
  https://bit.ly/2ox4IFG ([https](https://bit.ly/2ox4IFG) result 301).
* [ ] http://contributor-covenant.org with 1 occurrences migrated to:  
  https://contributor-covenant.org ([https](https://contributor-covenant.org) result 301).
* [ ] http://contributor-covenant.org/version/1/3/0/ with 1 occurrences migrated to:  
  https://contributor-covenant.org/version/1/3/0/ ([https](https://contributor-covenant.org/version/1/3/0/) result 301).
* [ ] http://dl.bintray.com/big-data/generic/2018-05-14-cmu-graph_opt.pb with 3 occurrences migrated to:  
  https://dl.bintray.com/big-data/generic/2018-05-14-cmu-graph_opt.pb ([https](https://dl.bintray.com/big-data/generic/2018-05-14-cmu-graph_opt.pb) result 302).
* [ ] http://dl.bintray.com/big-data/generic/2018-30-05-mobilenet_thin_graph_opt.pb with 3 occurrences migrated to:  
  https://dl.bintray.com/big-data/generic/2018-30-05-mobilenet_thin_graph_opt.pb ([https](https://dl.bintray.com/big-data/generic/2018-30-05-mobilenet_thin_graph_opt.pb) result 302).
* [ ] http://dl.bintray.com/big-data/generic/faster_rcnn_resnet101_coco_2018_01_28_frozen_inference_graph.pb with 3 occurrences migrated to:  
  https://dl.bintray.com/big-data/generic/faster_rcnn_resnet101_coco_2018_01_28_frozen_inference_graph.pb ([https](https://dl.bintray.com/big-data/generic/faster_rcnn_resnet101_coco_2018_01_28_frozen_inference_graph.pb) result 302).
* [ ] http://dl.bintray.com/big-data/generic/minimal_graph.proto with 2 occurrences migrated to:  
  https://dl.bintray.com/big-data/generic/minimal_graph.proto ([https](https://dl.bintray.com/big-data/generic/minimal_graph.proto) result 302).
* [ ] http://dl.bintray.com/big-data/generic/ssdlite_mobilenet_v2_coco_2018_05_09_frozen_inference_graph.pb with 2 occurrences migrated to:  
  https://dl.bintray.com/big-data/generic/ssdlite_mobilenet_v2_coco_2018_05_09_frozen_inference_graph.pb ([https](https://dl.bintray.com/big-data/generic/ssdlite_mobilenet_v2_coco_2018_05_09_frozen_inference_graph.pb) result 302).
* [ ] http://dl.bintray.com/big-data/generic/tensorflow_inception_graph.pb with 2 occurrences migrated to:  
  https://dl.bintray.com/big-data/generic/tensorflow_inception_graph.pb ([https](https://dl.bintray.com/big-data/generic/tensorflow_inception_graph.pb) result 302).
* [ ] http://dl.bintray.com/big-data/generic/vocab.csv with 2 occurrences migrated to:  
  https://dl.bintray.com/big-data/generic/vocab.csv ([https](https://dl.bintray.com/big-data/generic/vocab.csv) result 302).