### PR TITLE
URL Cleanup

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
                                  Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -192,7 +192,7 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-common-tensorflow/src/main/java/org/springframework/cloud/stream/app/tensorflow/processor/DefaultOutputMessageBuilder.java
+++ b/spring-cloud-starter-stream-common-tensorflow/src/main/java/org/springframework/cloud/stream/app/tensorflow/processor/DefaultOutputMessageBuilder.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-common-tensorflow/src/main/java/org/springframework/cloud/stream/app/tensorflow/processor/JsonTensor.java
+++ b/spring-cloud-starter-stream-common-tensorflow/src/main/java/org/springframework/cloud/stream/app/tensorflow/processor/JsonTensor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-common-tensorflow/src/main/java/org/springframework/cloud/stream/app/tensorflow/processor/OutputMessageBuilder.java
+++ b/spring-cloud-starter-stream-common-tensorflow/src/main/java/org/springframework/cloud/stream/app/tensorflow/processor/OutputMessageBuilder.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-common-tensorflow/src/main/java/org/springframework/cloud/stream/app/tensorflow/processor/OutputMode.java
+++ b/spring-cloud-starter-stream-common-tensorflow/src/main/java/org/springframework/cloud/stream/app/tensorflow/processor/OutputMode.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-common-tensorflow/src/main/java/org/springframework/cloud/stream/app/tensorflow/processor/TensorFlowService.java
+++ b/spring-cloud-starter-stream-common-tensorflow/src/main/java/org/springframework/cloud/stream/app/tensorflow/processor/TensorFlowService.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-common-tensorflow/src/main/java/org/springframework/cloud/stream/app/tensorflow/processor/TensorJsonConverter.java
+++ b/spring-cloud-starter-stream-common-tensorflow/src/main/java/org/springframework/cloud/stream/app/tensorflow/processor/TensorJsonConverter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-common-tensorflow/src/main/java/org/springframework/cloud/stream/app/tensorflow/processor/TensorflowCommonProcessorConfiguration.java
+++ b/spring-cloud-starter-stream-common-tensorflow/src/main/java/org/springframework/cloud/stream/app/tensorflow/processor/TensorflowCommonProcessorConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-common-tensorflow/src/main/java/org/springframework/cloud/stream/app/tensorflow/processor/TensorflowCommonProcessorProperties.java
+++ b/spring-cloud-starter-stream-common-tensorflow/src/main/java/org/springframework/cloud/stream/app/tensorflow/processor/TensorflowCommonProcessorProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-common-tensorflow/src/main/java/org/springframework/cloud/stream/app/tensorflow/processor/TensorflowInputConverter.java
+++ b/spring-cloud-starter-stream-common-tensorflow/src/main/java/org/springframework/cloud/stream/app/tensorflow/processor/TensorflowInputConverter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-common-tensorflow/src/main/java/org/springframework/cloud/stream/app/tensorflow/processor/TensorflowOutputConverter.java
+++ b/spring-cloud-starter-stream-common-tensorflow/src/main/java/org/springframework/cloud/stream/app/tensorflow/processor/TensorflowOutputConverter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-common-tensorflow/src/main/java/org/springframework/cloud/stream/app/tensorflow/util/GraphicsUtils.java
+++ b/spring-cloud-starter-stream-common-tensorflow/src/main/java/org/springframework/cloud/stream/app/tensorflow/util/GraphicsUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-common-tensorflow/src/main/java/org/springframework/cloud/stream/app/tensorflow/util/ModelExtractor.java
+++ b/spring-cloud-starter-stream-common-tensorflow/src/main/java/org/springframework/cloud/stream/app/tensorflow/util/ModelExtractor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-common-tensorflow/src/test/java/org/springframework/cloud/stream/app/tensorflow/util/ModelExtractorTest.java
+++ b/spring-cloud-starter-stream-common-tensorflow/src/test/java/org/springframework/cloud/stream/app/tensorflow/util/ModelExtractorTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-processor-image-recognition/src/main/java/org/springframework/cloud/stream/app/image/recognition/processor/ImageRecognitionOutputMessageBuilder.java
+++ b/spring-cloud-starter-stream-processor-image-recognition/src/main/java/org/springframework/cloud/stream/app/image/recognition/processor/ImageRecognitionOutputMessageBuilder.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-processor-image-recognition/src/main/java/org/springframework/cloud/stream/app/image/recognition/processor/ImageRecognitionProcessorConfiguration.java
+++ b/spring-cloud-starter-stream-processor-image-recognition/src/main/java/org/springframework/cloud/stream/app/image/recognition/processor/ImageRecognitionProcessorConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-processor-image-recognition/src/main/java/org/springframework/cloud/stream/app/image/recognition/processor/ImageRecognitionProcessorProperties.java
+++ b/spring-cloud-starter-stream-processor-image-recognition/src/main/java/org/springframework/cloud/stream/app/image/recognition/processor/ImageRecognitionProcessorProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-processor-image-recognition/src/main/java/org/springframework/cloud/stream/app/image/recognition/processor/ImageRecognitionTensorflowInputConverter.java
+++ b/spring-cloud-starter-stream-processor-image-recognition/src/main/java/org/springframework/cloud/stream/app/image/recognition/processor/ImageRecognitionTensorflowInputConverter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-processor-image-recognition/src/main/java/org/springframework/cloud/stream/app/image/recognition/processor/ImageRecognitionTensorflowOutputConverter.java
+++ b/spring-cloud-starter-stream-processor-image-recognition/src/main/java/org/springframework/cloud/stream/app/image/recognition/processor/ImageRecognitionTensorflowOutputConverter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-processor-image-recognition/src/test/java/org/springframework/cloud/stream/app/image/recognition/processor/ImageRecognitionProcessorPropertiesTests.java
+++ b/spring-cloud-starter-stream-processor-image-recognition/src/test/java/org/springframework/cloud/stream/app/image/recognition/processor/ImageRecognitionProcessorPropertiesTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-processor-image-recognition/src/test/java/org/springframework/cloud/stream/app/image/recognition/processor/ImageRecognitionProcessorWhitelistPropertiesTests.java
+++ b/spring-cloud-starter-stream-processor-image-recognition/src/test/java/org/springframework/cloud/stream/app/image/recognition/processor/ImageRecognitionProcessorWhitelistPropertiesTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-processor-image-recognition/src/test/java/org/springframework/cloud/stream/app/image/recognition/processor/inception/ImageRecognitionTensorflowProcessorIntegrationTests.java
+++ b/spring-cloud-starter-stream-processor-image-recognition/src/test/java/org/springframework/cloud/stream/app/image/recognition/processor/inception/ImageRecognitionTensorflowProcessorIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-processor-object-detection/src/main/java/org/springframework/cloud/stream/app/object/detection/mocel/ObjectDetection.java
+++ b/spring-cloud-starter-stream-processor-object-detection/src/main/java/org/springframework/cloud/stream/app/object/detection/mocel/ObjectDetection.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-processor-object-detection/src/main/java/org/springframework/cloud/stream/app/object/detection/processor/GraphicsUtils.java
+++ b/spring-cloud-starter-stream-processor-object-detection/src/main/java/org/springframework/cloud/stream/app/object/detection/processor/GraphicsUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-processor-object-detection/src/main/java/org/springframework/cloud/stream/app/object/detection/processor/ObjectDetectionOutputMessageBuilder.java
+++ b/spring-cloud-starter-stream-processor-object-detection/src/main/java/org/springframework/cloud/stream/app/object/detection/processor/ObjectDetectionOutputMessageBuilder.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-processor-object-detection/src/main/java/org/springframework/cloud/stream/app/object/detection/processor/ObjectDetectionProcessorConfiguration.java
+++ b/spring-cloud-starter-stream-processor-object-detection/src/main/java/org/springframework/cloud/stream/app/object/detection/processor/ObjectDetectionProcessorConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-processor-object-detection/src/main/java/org/springframework/cloud/stream/app/object/detection/processor/ObjectDetectionProcessorProperties.java
+++ b/spring-cloud-starter-stream-processor-object-detection/src/main/java/org/springframework/cloud/stream/app/object/detection/processor/ObjectDetectionProcessorProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-processor-object-detection/src/main/java/org/springframework/cloud/stream/app/object/detection/processor/ObjectDetectionTensorflowInputConverter.java
+++ b/spring-cloud-starter-stream-processor-object-detection/src/main/java/org/springframework/cloud/stream/app/object/detection/processor/ObjectDetectionTensorflowInputConverter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-processor-object-detection/src/main/java/org/springframework/cloud/stream/app/object/detection/processor/ObjectDetectionTensorflowOutputConverter.java
+++ b/spring-cloud-starter-stream-processor-object-detection/src/main/java/org/springframework/cloud/stream/app/object/detection/processor/ObjectDetectionTensorflowOutputConverter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-processor-object-detection/src/test/java/org/springframework/cloud/stream/app/object/detection/processor/ObjectDetectionProcessorPropertiesTests.java
+++ b/spring-cloud-starter-stream-processor-object-detection/src/test/java/org/springframework/cloud/stream/app/object/detection/processor/ObjectDetectionProcessorPropertiesTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-processor-object-detection/src/test/java/org/springframework/cloud/stream/app/object/detection/processor/ObjectDetectionProcessorWhitelistPropertiesTests.java
+++ b/spring-cloud-starter-stream-processor-object-detection/src/test/java/org/springframework/cloud/stream/app/object/detection/processor/ObjectDetectionProcessorWhitelistPropertiesTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-processor-object-detection/src/test/java/org/springframework/cloud/stream/app/object/detection/processor/detection/ObjectDetectionTensorflowProcessorIntegrationTests.java
+++ b/spring-cloud-starter-stream-processor-object-detection/src/test/java/org/springframework/cloud/stream/app/object/detection/processor/detection/ObjectDetectionTensorflowProcessorIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-processor-pose-estimation/src/main/java/org/springframework/cloud/stream/app/pose/estimation/model/Body.java
+++ b/spring-cloud-starter-stream-processor-pose-estimation/src/main/java/org/springframework/cloud/stream/app/pose/estimation/model/Body.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-processor-pose-estimation/src/main/java/org/springframework/cloud/stream/app/pose/estimation/model/Limb.java
+++ b/spring-cloud-starter-stream-processor-pose-estimation/src/main/java/org/springframework/cloud/stream/app/pose/estimation/model/Limb.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-processor-pose-estimation/src/main/java/org/springframework/cloud/stream/app/pose/estimation/model/Model.java
+++ b/spring-cloud-starter-stream-processor-pose-estimation/src/main/java/org/springframework/cloud/stream/app/pose/estimation/model/Model.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-processor-pose-estimation/src/main/java/org/springframework/cloud/stream/app/pose/estimation/model/Part.java
+++ b/spring-cloud-starter-stream-processor-pose-estimation/src/main/java/org/springframework/cloud/stream/app/pose/estimation/model/Part.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-processor-pose-estimation/src/main/java/org/springframework/cloud/stream/app/pose/estimation/model/PoseMatcher.java
+++ b/spring-cloud-starter-stream-processor-pose-estimation/src/main/java/org/springframework/cloud/stream/app/pose/estimation/model/PoseMatcher.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-processor-pose-estimation/src/main/java/org/springframework/cloud/stream/app/pose/estimation/processor/DebugVisualizationUtility.java
+++ b/spring-cloud-starter-stream-processor-pose-estimation/src/main/java/org/springframework/cloud/stream/app/pose/estimation/processor/DebugVisualizationUtility.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-processor-pose-estimation/src/main/java/org/springframework/cloud/stream/app/pose/estimation/processor/PoseEstimateOutputMessageBuilder.java
+++ b/spring-cloud-starter-stream-processor-pose-estimation/src/main/java/org/springframework/cloud/stream/app/pose/estimation/processor/PoseEstimateOutputMessageBuilder.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-processor-pose-estimation/src/main/java/org/springframework/cloud/stream/app/pose/estimation/processor/PoseEstimationProcessorConfiguration.java
+++ b/spring-cloud-starter-stream-processor-pose-estimation/src/main/java/org/springframework/cloud/stream/app/pose/estimation/processor/PoseEstimationProcessorConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-processor-pose-estimation/src/main/java/org/springframework/cloud/stream/app/pose/estimation/processor/PoseEstimationProcessorProperties.java
+++ b/spring-cloud-starter-stream-processor-pose-estimation/src/main/java/org/springframework/cloud/stream/app/pose/estimation/processor/PoseEstimationProcessorProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-processor-pose-estimation/src/main/java/org/springframework/cloud/stream/app/pose/estimation/processor/PoseEstimationTensorflowInputConverter.java
+++ b/spring-cloud-starter-stream-processor-pose-estimation/src/main/java/org/springframework/cloud/stream/app/pose/estimation/processor/PoseEstimationTensorflowInputConverter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-processor-pose-estimation/src/main/java/org/springframework/cloud/stream/app/pose/estimation/processor/PoseEstimationTensorflowOutputConverter.java
+++ b/spring-cloud-starter-stream-processor-pose-estimation/src/main/java/org/springframework/cloud/stream/app/pose/estimation/processor/PoseEstimationTensorflowOutputConverter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-processor-pose-estimation/src/test/java/org/springframework/cloud/stream/app/pose/estimation/model/PoseMatcherTest.java
+++ b/spring-cloud-starter-stream-processor-pose-estimation/src/test/java/org/springframework/cloud/stream/app/pose/estimation/model/PoseMatcherTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-processor-pose-estimation/src/test/java/org/springframework/cloud/stream/app/pose/estimation/processor/PoseEstimationProcessorPropertiesTests.java
+++ b/spring-cloud-starter-stream-processor-pose-estimation/src/test/java/org/springframework/cloud/stream/app/pose/estimation/processor/PoseEstimationProcessorPropertiesTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-processor-pose-estimation/src/test/java/org/springframework/cloud/stream/app/pose/estimation/processor/PoseEstimationProcessorWhitelistPropertiesTests.java
+++ b/spring-cloud-starter-stream-processor-pose-estimation/src/test/java/org/springframework/cloud/stream/app/pose/estimation/processor/PoseEstimationProcessorWhitelistPropertiesTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-processor-pose-estimation/src/test/java/org/springframework/cloud/stream/app/pose/estimation/processor/PoseEstimationTensorflowProcessorIntegrationTests.java
+++ b/spring-cloud-starter-stream-processor-pose-estimation/src/test/java/org/springframework/cloud/stream/app/pose/estimation/processor/PoseEstimationTensorflowProcessorIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-processor-tensorflow/src/main/java/org/springframework/cloud/stream/app/tensorflow/processor/TensorflowProcessorConfiguration.java
+++ b/spring-cloud-starter-stream-processor-tensorflow/src/main/java/org/springframework/cloud/stream/app/tensorflow/processor/TensorflowProcessorConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-processor-tensorflow/src/test/java/org/springframework/cloud/stream/app/tensorflow/processor/TensorJsonConverterTests.java
+++ b/spring-cloud-starter-stream-processor-tensorflow/src/test/java/org/springframework/cloud/stream/app/tensorflow/processor/TensorJsonConverterTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-processor-tensorflow/src/test/java/org/springframework/cloud/stream/app/tensorflow/processor/TensorflowProcessorPropertiesTests.java
+++ b/spring-cloud-starter-stream-processor-tensorflow/src/test/java/org/springframework/cloud/stream/app/tensorflow/processor/TensorflowProcessorPropertiesTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-processor-tensorflow/src/test/java/org/springframework/cloud/stream/app/tensorflow/processor/TensorflowProcessorWhitelistPropertiesTests.java
+++ b/spring-cloud-starter-stream-processor-tensorflow/src/test/java/org/springframework/cloud/stream/app/tensorflow/processor/TensorflowProcessorWhitelistPropertiesTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-processor-tensorflow/src/test/java/org/springframework/cloud/stream/app/tensorflow/processor/logisticregression/LinearRegressionTensorflowProcessorIntegrationTests.java
+++ b/spring-cloud-starter-stream-processor-tensorflow/src/test/java/org/springframework/cloud/stream/app/tensorflow/processor/logisticregression/LinearRegressionTensorflowProcessorIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-processor-twitter-sentiment/src/main/java/org/springframework/cloud/stream/app/twitter/sentiment/processor/Sentiment.java
+++ b/spring-cloud-starter-stream-processor-twitter-sentiment/src/main/java/org/springframework/cloud/stream/app/twitter/sentiment/processor/Sentiment.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-processor-twitter-sentiment/src/main/java/org/springframework/cloud/stream/app/twitter/sentiment/processor/TwitterSentimentProcessorConfiguration.java
+++ b/spring-cloud-starter-stream-processor-twitter-sentiment/src/main/java/org/springframework/cloud/stream/app/twitter/sentiment/processor/TwitterSentimentProcessorConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-processor-twitter-sentiment/src/main/java/org/springframework/cloud/stream/app/twitter/sentiment/processor/TwitterSentimentProcessorProperties.java
+++ b/spring-cloud-starter-stream-processor-twitter-sentiment/src/main/java/org/springframework/cloud/stream/app/twitter/sentiment/processor/TwitterSentimentProcessorProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-processor-twitter-sentiment/src/main/java/org/springframework/cloud/stream/app/twitter/sentiment/processor/TwitterSentimentTensorflowInputConverter.java
+++ b/spring-cloud-starter-stream-processor-twitter-sentiment/src/main/java/org/springframework/cloud/stream/app/twitter/sentiment/processor/TwitterSentimentTensorflowInputConverter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-processor-twitter-sentiment/src/main/java/org/springframework/cloud/stream/app/twitter/sentiment/processor/TwitterSentimentTensorflowOutputConverter.java
+++ b/spring-cloud-starter-stream-processor-twitter-sentiment/src/main/java/org/springframework/cloud/stream/app/twitter/sentiment/processor/TwitterSentimentTensorflowOutputConverter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-processor-twitter-sentiment/src/main/java/org/springframework/cloud/stream/app/twitter/sentiment/processor/WordVocabulary.java
+++ b/spring-cloud-starter-stream-processor-twitter-sentiment/src/main/java/org/springframework/cloud/stream/app/twitter/sentiment/processor/WordVocabulary.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-processor-twitter-sentiment/src/test/java/org/springframework/cloud/stream/app/twitter/sentiment/processor/TwitterSentimentProcessorPropertiesTests.java
+++ b/spring-cloud-starter-stream-processor-twitter-sentiment/src/test/java/org/springframework/cloud/stream/app/twitter/sentiment/processor/TwitterSentimentProcessorPropertiesTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-processor-twitter-sentiment/src/test/java/org/springframework/cloud/stream/app/twitter/sentiment/processor/twitter/TwitterSentimentTensorflowProcessorIntegrationTests.java
+++ b/spring-cloud-starter-stream-processor-twitter-sentiment/src/test/java/org/springframework/cloud/stream/app/twitter/sentiment/processor/twitter/TwitterSentimentTensorflowProcessorIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/tensorflow-app-starters-test-support/src/main/java/org/springframework/cloud/stream/app/test/tensorflow/JsonUtils.java
+++ b/tensorflow-app-starters-test-support/src/main/java/org/springframework/cloud/stream/app/test/tensorflow/JsonUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/tensorflow-app-starters-test-support/src/main/java/org/springframework/cloud/stream/app/test/tensorflow/TensorflowProcessorTestConfiguration.java
+++ b/tensorflow-app-starters-test-support/src/main/java/org/springframework/cloud/stream/app/test/tensorflow/TensorflowProcessorTestConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *       http://www.apache.org/licenses/LICENSE-2.0
+ *       https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://www.apache.org/licenses/ with 1 occurrences migrated to:  
  https://www.apache.org/licenses/ ([https](https://www.apache.org/licenses/) result 200).
* [ ] http://www.apache.org/licenses/LICENSE-2.0 with 62 occurrences migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0 ([https](https://www.apache.org/licenses/LICENSE-2.0) result 200).