### PR TITLE
URL Cleanup

### DIFF
--- a/CODE_OF_CONDUCT.adoc
+++ b/CODE_OF_CONDUCT.adoc
@@ -40,5 +40,5 @@ appropriate to the circumstances. Maintainers are obligated to maintain confiden
 with regard to the reporter of an incident.
 
 This Code of Conduct is adapted from the
-http://contributor-covenant.org[Contributor Covenant], version 1.3.0, available at
-http://contributor-covenant.org/version/1/3/0/[contributor-covenant.org/version/1/3/0/]
+https://contributor-covenant.org[Contributor Covenant], version 1.3.0, available at
+https://contributor-covenant.org/version/1/3/0/[contributor-covenant.org/version/1/3/0/]

--- a/spring-cloud-starter-stream-common-tensorflow/src/main/java/org/springframework/cloud/stream/app/tensorflow/processor/TensorflowInputConverter.java
+++ b/spring-cloud-starter-stream-common-tensorflow/src/main/java/org/springframework/cloud/stream/app/tensorflow/processor/TensorflowInputConverter.java
@@ -28,7 +28,7 @@ import java.util.Map;
  * is encoded into key/value Map or flat key/value JSON message. Where each key in the map corresponds to a model input
  * placeholder and the value is compliant with TensorFlow's {@link org.tensorflow.DataType}.
  *
- *  @see <a href="http://bit.ly/2ox4IFG">TwitterSentimentTensorflowInputConverter.java</a> for how to build custom {@link TensorflowInputConverter}.
+ *  @see <a href="https://bit.ly/2ox4IFG">TwitterSentimentTensorflowInputConverter.java</a> for how to build custom {@link TensorflowInputConverter}.
  *
  * @author Christian Tzolov
  */

--- a/spring-cloud-starter-stream-common-tensorflow/src/main/java/org/springframework/cloud/stream/app/tensorflow/processor/TensorflowOutputConverter.java
+++ b/spring-cloud-starter-stream-common-tensorflow/src/main/java/org/springframework/cloud/stream/app/tensorflow/processor/TensorflowOutputConverter.java
@@ -39,7 +39,7 @@ import java.util.Map;
  * The helper {@link TensorTupleConverter#toTensor(Tuple)} static method helps to do this.
  *
  * A better approach is to provide a custom {@link TensorflowOutputConverter} implementation.
- * @see <a href="http://bit.ly/2pKBghe">TwitterSentimentTensorflowOutputConverter.java</a> for how to build custom {@link TensorflowOutputConverter}.
+ * @see <a href="https://bit.ly/2pKBghe">TwitterSentimentTensorflowOutputConverter.java</a> for how to build custom {@link TensorflowOutputConverter}.
  *
  * @author Christian Tzolov
  */

--- a/spring-cloud-starter-stream-processor-twitter-sentiment/README.adoc
+++ b/spring-cloud-starter-stream-processor-twitter-sentiment/README.adoc
@@ -89,8 +89,8 @@ using the pre-build `minimal_graph.proto` and `vocab.csv`:
 ```
 tweets=twitterstream --access-token-secret=xxx --access-token=xxx --consumer-secret=xxx --consumer-key=xxx \
 | filter --expression=#jsonPath(payload,'$.lang')=='en' \
-| twitter-sentimet --vocabulary='http://dl.bintray.com/big-data/generic/vocab.csv' \
-   --output-name=output/Softmax --model='http://dl.bintray.com/big-data/generic/minimal_graph.proto' \
+| twitter-sentimet --vocabulary='https://dl.bintray.com/big-data/generic/vocab.csv' \
+   --output-name=output/Softmax --model='https://dl.bintray.com/big-data/generic/minimal_graph.proto' \
    --model-fetch=output/Softmax \
 | log
 ```

--- a/spring-cloud-starter-stream-processor-twitter-sentiment/src/test/java/org/springframework/cloud/stream/app/twitter/sentiment/processor/twitter/TwitterSentimentTensorflowProcessorIntegrationTests.java
+++ b/spring-cloud-starter-stream-processor-twitter-sentiment/src/test/java/org/springframework/cloud/stream/app/twitter/sentiment/processor/twitter/TwitterSentimentTensorflowProcessorIntegrationTests.java
@@ -48,9 +48,9 @@ import org.springframework.test.context.junit4.SpringRunner;
 @SpringBootTest(
 		webEnvironment = SpringBootTest.WebEnvironment.NONE,
 		properties = {
-				"tensorflow.model=http://dl.bintray.com/big-data/generic/minimal_graph.proto",
+				"tensorflow.model=https://dl.bintray.com/big-data/generic/minimal_graph.proto",
 				"tensorflow.modelFetch=output/Softmax",
-				"tensorflow.twitter.vocabulary=http://dl.bintray.com/big-data/generic/vocab.csv"
+				"tensorflow.twitter.vocabulary=https://dl.bintray.com/big-data/generic/vocab.csv"
 		})
 @DirtiesContext
 @Ignore("Exclude the Twitter Sentiment Processor Integration Test until a proper Mock TF Model is provided!")


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://bit.ly/2ox4IFG with 1 occurrences migrated to:  
  https://bit.ly/2ox4IFG ([https](https://bit.ly/2ox4IFG) result 301).
* [ ] http://bit.ly/2pKBghe with 1 occurrences migrated to:  
  https://bit.ly/2pKBghe ([https](https://bit.ly/2pKBghe) result 301).
* [ ] http://contributor-covenant.org with 1 occurrences migrated to:  
  https://contributor-covenant.org ([https](https://contributor-covenant.org) result 301).
* [ ] http://contributor-covenant.org/version/1/3/0/ with 1 occurrences migrated to:  
  https://contributor-covenant.org/version/1/3/0/ ([https](https://contributor-covenant.org/version/1/3/0/) result 301).
* [ ] http://dl.bintray.com/big-data/generic/minimal_graph.proto with 2 occurrences migrated to:  
  https://dl.bintray.com/big-data/generic/minimal_graph.proto ([https](https://dl.bintray.com/big-data/generic/minimal_graph.proto) result 302).
* [ ] http://dl.bintray.com/big-data/generic/vocab.csv with 2 occurrences migrated to:  
  https://dl.bintray.com/big-data/generic/vocab.csv ([https](https://dl.bintray.com/big-data/generic/vocab.csv) result 302).