### PR TITLE
URL Cleanup

### DIFF
--- a/CODE_OF_CONDUCT.adoc
+++ b/CODE_OF_CONDUCT.adoc
@@ -40,5 +40,5 @@ appropriate to the circumstances. Maintainers are obligated to maintain confiden
 with regard to the reporter of an incident.
 
 This Code of Conduct is adapted from the
-http://contributor-covenant.org[Contributor Covenant], version 1.3.0, available at
-http://contributor-covenant.org/version/1/3/0/[contributor-covenant.org/version/1/3/0/]
+https://contributor-covenant.org[Contributor Covenant], version 1.3.0, available at
+https://contributor-covenant.org/version/1/3/0/[contributor-covenant.org/version/1/3/0/]

--- a/spring-cloud-starter-stream-common-tensorflow/src/main/java/org/springframework/cloud/stream/app/tensorflow/processor/TensorflowInputConverter.java
+++ b/spring-cloud-starter-stream-common-tensorflow/src/main/java/org/springframework/cloud/stream/app/tensorflow/processor/TensorflowInputConverter.java
@@ -28,7 +28,7 @@ import java.util.Map;
  * is encoded into key/value Map or flat key/value JSON message. Where each key in the map corresponds to a model input
  * placeholder and the value is compliant with TensorFlow's {@link org.tensorflow.DataType}.
  *
- *  @see <a href="http://bit.ly/2ox4IFG">TwitterSentimentTensorflowInputConverter.java</a> for how to build custom {@link TensorflowInputConverter}.
+ *  @see <a href="https://bit.ly/2ox4IFG">TwitterSentimentTensorflowInputConverter.java</a> for how to build custom {@link TensorflowInputConverter}.
  *
  * @author Christian Tzolov
  */

--- a/spring-cloud-starter-stream-common-tensorflow/src/main/java/org/springframework/cloud/stream/app/tensorflow/processor/TensorflowOutputConverter.java
+++ b/spring-cloud-starter-stream-common-tensorflow/src/main/java/org/springframework/cloud/stream/app/tensorflow/processor/TensorflowOutputConverter.java
@@ -39,7 +39,7 @@ import java.util.Map;
  * The helper {@link TensorTupleConverter#toTensor(Tuple)} static method helps to do this.
  *
  * A better approach is to provide a custom {@link TensorflowOutputConverter} implementation.
- * @see <a href="http://bit.ly/2pKBghe">TwitterSentimentTensorflowOutputConverter.java</a> for how to build custom {@link TensorflowOutputConverter}.
+ * @see <a href="https://bit.ly/2pKBghe">TwitterSentimentTensorflowOutputConverter.java</a> for how to build custom {@link TensorflowOutputConverter}.
  *
  * @author Christian Tzolov
  */

--- a/spring-cloud-starter-stream-processor-image-recognition/src/test/java/org/springframework/cloud/stream/app/image/recognition/processor/inception/ImageRecognitionTensorflowProcessorIntegrationTests.java
+++ b/spring-cloud-starter-stream-processor-image-recognition/src/test/java/org/springframework/cloud/stream/app/image/recognition/processor/inception/ImageRecognitionTensorflowProcessorIntegrationTests.java
@@ -50,9 +50,9 @@ import static org.hamcrest.Matchers.equalTo;
 @SpringBootTest(
 		webEnvironment = SpringBootTest.WebEnvironment.NONE,
 		properties = {
-				"tensorflow.model=http://dl.bintray.com/big-data/generic/tensorflow_inception_graph.pb",
+				"tensorflow.model=https://dl.bintray.com/big-data/generic/tensorflow_inception_graph.pb",
 				"tensorflow.modelFetch=output",
-				"tensorflow.image.recognition.labels=http://dl.bintray.com/big-data/generic/imagenet_comp_graph_label_strings.txt"
+				"tensorflow.image.recognition.labels=https://dl.bintray.com/big-data/generic/imagenet_comp_graph_label_strings.txt"
 		})
 @DirtiesContext
 public abstract class ImageRecognitionTensorflowProcessorIntegrationTests {

--- a/spring-cloud-starter-stream-processor-object-detection/README.adoc
+++ b/spring-cloud-starter-stream-processor-object-detection/README.adoc
@@ -7,8 +7,8 @@ The new https://github.com/spring-cloud-stream-app-starters/tensorflow/tree/mast
 If the pre-trained model is not set explicitly set then following defaults are used:
 
 * `tensorflow.modelFetch` : `detection_scores,detection_classes,detection_boxes,num_detections`
-* `tensorflow.model` : `http://dl.bintray.com/big-data/generic/faster_rcnn_resnet101_coco_2018_01_28_frozen_inference_graph.pb`
-* `tensorflow.object.detection.labels` : `http://dl.bintray.com/big-data/generic/mscoco_label_map.pbtxt`
+* `tensorflow.model` : `https://dl.bintray.com/big-data/generic/faster_rcnn_resnet101_coco_2018_01_28_frozen_inference_graph.pb`
+* `tensorflow.object.detection.labels` : `https://dl.bintray.com/big-data/generic/mscoco_label_map.pbtxt`
 
 The following diagram illustrates a Spring Cloud Data Flow streaming pipeline that predicts object types from the images in real-time.
 
@@ -78,9 +78,9 @@ And here is a example pipeline that process images in `file` source and outputs 
 ```
 object-detector-stream=file --directory='/tmp/images'
 | object-detector --tensorflow.mode=header
-    --tensorflow.model='http://dl.bintray.com/big-data/generic/faster_rcnn_resnet101_coco_2018_01_28_frozen_inference_graph.pb'
+    --tensorflow.model='https://dl.bintray.com/big-data/generic/faster_rcnn_resnet101_coco_2018_01_28_frozen_inference_graph.pb'
     --tensorflow.model-fetch='detection_scores,detection_classes,detection_boxes'
-    --tensorflow.object.detection.labels='http://dl.bintray.com/big-data/generic/mscoco_label_map.pbtxt'
+    --tensorflow.object.detection.labels='https://dl.bintray.com/big-data/generic/mscoco_label_map.pbtxt'
 | image-viewer
 ```
 

--- a/spring-cloud-starter-stream-processor-object-detection/src/main/java/org/springframework/cloud/stream/app/object/detection/processor/ObjectDetectionTensorflowOutputConverter.java
+++ b/spring-cloud-starter-stream-processor-object-detection/src/main/java/org/springframework/cloud/stream/app/object/detection/processor/ObjectDetectionTensorflowOutputConverter.java
@@ -39,7 +39,7 @@ import org.springframework.util.StringUtils;
 
 /**
  * Converts the Tensorflow Object Detection result into {@link Tuple} object.
- * The pre-trained Object Detection models (http://bit.ly/2osxMAY) produce 3 tensor outputs:
+ * The pre-trained Object Detection models (https://bit.ly/2osxMAY) produce 3 tensor outputs:
  *  (1) detection_classes - containing the ids of detected objects, (2) detection_scores - confidence probabilities of the
  *  detected object and (3) detection_boxes - the object bounding boxes withing the images.
  *

--- a/spring-cloud-starter-stream-processor-object-detection/src/main/resources/config/application.yml
+++ b/spring-cloud-starter-stream-processor-object-detection/src/main/resources/config/application.yml
@@ -1,6 +1,6 @@
 tensorflow:
   modelFetch: detection_scores,detection_classes,detection_boxes,num_detections
-  model: http://dl.bintray.com/big-data/generic/ssdlite_mobilenet_v2_coco_2018_05_09_frozen_inference_graph.pb
+  model: https://dl.bintray.com/big-data/generic/ssdlite_mobilenet_v2_coco_2018_05_09_frozen_inference_graph.pb
   object:
     detection:
-      labels: http://dl.bintray.com/big-data/generic/mscoco_label_map.pbtxt
+      labels: https://dl.bintray.com/big-data/generic/mscoco_label_map.pbtxt

--- a/spring-cloud-starter-stream-processor-object-detection/src/test/java/org/springframework/cloud/stream/app/object/detection/processor/detection/ObjectDetectionTensorflowProcessorIntegrationTests.java
+++ b/spring-cloud-starter-stream-processor-object-detection/src/test/java/org/springframework/cloud/stream/app/object/detection/processor/detection/ObjectDetectionTensorflowProcessorIntegrationTests.java
@@ -52,10 +52,10 @@ import static org.hamcrest.Matchers.equalTo;
 		properties = {
 				//"tensorflow.modelFetch=detection_scores,detection_classes,detection_boxes,detection_masks,num_detections",
 				"tensorflow.modelFetch=detection_scores,detection_classes,detection_boxes,num_detections",
-				//"tensorflow.model=http://dl.bintray.com/big-data/generic/faster_rcnn_resnet101_coco_2018_01_28_frozen_inference_graph.pb",
-				"tensorflow.model=http://dl.bintray.com/big-data/generic/ssdlite_mobilenet_v2_coco_2018_05_09_frozen_inference_graph.pb",
+				//"tensorflow.model=https://dl.bintray.com/big-data/generic/faster_rcnn_resnet101_coco_2018_01_28_frozen_inference_graph.pb",
+				"tensorflow.model=https://dl.bintray.com/big-data/generic/ssdlite_mobilenet_v2_coco_2018_05_09_frozen_inference_graph.pb",
 				//"tensorflow.model=file:/Users/ctzolov/Downloads/ssd_mobilenet_v2_coco_2018_03_29/frozen_inference_graph.pb",
-				"tensorflow.object.detection.labels=http://dl.bintray.com/big-data/generic/mscoco_label_map.pbtxt",
+				"tensorflow.object.detection.labels=https://dl.bintray.com/big-data/generic/mscoco_label_map.pbtxt",
 				//"tensorflow.model=file:/Users/ctzolov/Downloads/mask_rcnn_resnet101_atrous_coco_2018_01_28/frozen_inference_graph.pb"
 				//"tensorflow.model=file:/Users/ctzolov/Downloads/ssd_inception_v2_coco_2017_11_17/frozen_inference_graph.pb",
 				//"tensorflow.model=file:/Users/ctzolov/Downloads/faster_rcnn_inception_resnet_v2_atrous_lowproposals_oid_2018_01_28/frozen_inference_graph.pb",

--- a/spring-cloud-starter-stream-processor-twitter-sentiment/README.adoc
+++ b/spring-cloud-starter-stream-processor-twitter-sentiment/README.adoc
@@ -80,8 +80,8 @@ using the pre-build `minimal_graph.proto` and `vocab.csv`:
 ```
 tweets=twitterstream --access-token-secret=xxx --access-token=xxx --consumer-secret=xxx --consumer-key=xxx \
 | filter --expression=#jsonPath(payload,'$.lang')=='en' \
-| twitter-sentimet --vocabulary='http://dl.bintray.com/big-data/generic/vocab.csv' \
-   --output-name=output/Softmax --model='http://dl.bintray.com/big-data/generic/minimal_graph.proto' \
+| twitter-sentimet --vocabulary='https://dl.bintray.com/big-data/generic/vocab.csv' \
+   --output-name=output/Softmax --model='https://dl.bintray.com/big-data/generic/minimal_graph.proto' \
    --model-fetch=output/Softmax \
 | log
 ```

--- a/spring-cloud-starter-stream-processor-twitter-sentiment/src/test/java/org/springframework/cloud/stream/app/twitter/sentiment/processor/twitter/TwitterSentimentTensorflowProcessorIntegrationTests.java
+++ b/spring-cloud-starter-stream-processor-twitter-sentiment/src/test/java/org/springframework/cloud/stream/app/twitter/sentiment/processor/twitter/TwitterSentimentTensorflowProcessorIntegrationTests.java
@@ -48,9 +48,9 @@ import static org.hamcrest.Matchers.equalTo;
 @SpringBootTest(
 		webEnvironment = SpringBootTest.WebEnvironment.NONE,
 		properties = {
-				"tensorflow.model=http://dl.bintray.com/big-data/generic/minimal_graph.proto",
+				"tensorflow.model=https://dl.bintray.com/big-data/generic/minimal_graph.proto",
 				"tensorflow.modelFetch=output/Softmax",
-				"tensorflow.twitter.vocabulary=http://dl.bintray.com/big-data/generic/vocab.csv"
+				"tensorflow.twitter.vocabulary=https://dl.bintray.com/big-data/generic/vocab.csv"
 		})
 @DirtiesContext
 public abstract class TwitterSentimentTensorflowProcessorIntegrationTests {


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://dl.bintray.com/big-data/generic/imagenet_comp_graph_label_strings.txt with 1 occurrences migrated to:  
  https://dl.bintray.com/big-data/generic/imagenet_comp_graph_label_strings.txt ([https](https://dl.bintray.com/big-data/generic/imagenet_comp_graph_label_strings.txt) result 200).
* [ ] http://dl.bintray.com/big-data/generic/mscoco_label_map.pbtxt with 4 occurrences migrated to:  
  https://dl.bintray.com/big-data/generic/mscoco_label_map.pbtxt ([https](https://dl.bintray.com/big-data/generic/mscoco_label_map.pbtxt) result 200).
* [ ] http://bit.ly/2osxMAY with 1 occurrences migrated to:  
  https://bit.ly/2osxMAY ([https](https://bit.ly/2osxMAY) result 301).
* [ ] http://bit.ly/2ox4IFG with 1 occurrences migrated to:  
  https://bit.ly/2ox4IFG ([https](https://bit.ly/2ox4IFG) result 301).
* [ ] http://bit.ly/2pKBghe with 1 occurrences migrated to:  
  https://bit.ly/2pKBghe ([https](https://bit.ly/2pKBghe) result 301).
* [ ] http://contributor-covenant.org with 1 occurrences migrated to:  
  https://contributor-covenant.org ([https](https://contributor-covenant.org) result 301).
* [ ] http://contributor-covenant.org/version/1/3/0/ with 1 occurrences migrated to:  
  https://contributor-covenant.org/version/1/3/0/ ([https](https://contributor-covenant.org/version/1/3/0/) result 301).
* [ ] http://dl.bintray.com/big-data/generic/faster_rcnn_resnet101_coco_2018_01_28_frozen_inference_graph.pb with 3 occurrences migrated to:  
  https://dl.bintray.com/big-data/generic/faster_rcnn_resnet101_coco_2018_01_28_frozen_inference_graph.pb ([https](https://dl.bintray.com/big-data/generic/faster_rcnn_resnet101_coco_2018_01_28_frozen_inference_graph.pb) result 302).
* [ ] http://dl.bintray.com/big-data/generic/minimal_graph.proto with 2 occurrences migrated to:  
  https://dl.bintray.com/big-data/generic/minimal_graph.proto ([https](https://dl.bintray.com/big-data/generic/minimal_graph.proto) result 302).
* [ ] http://dl.bintray.com/big-data/generic/ssdlite_mobilenet_v2_coco_2018_05_09_frozen_inference_graph.pb with 2 occurrences migrated to:  
  https://dl.bintray.com/big-data/generic/ssdlite_mobilenet_v2_coco_2018_05_09_frozen_inference_graph.pb ([https](https://dl.bintray.com/big-data/generic/ssdlite_mobilenet_v2_coco_2018_05_09_frozen_inference_graph.pb) result 302).
* [ ] http://dl.bintray.com/big-data/generic/tensorflow_inception_graph.pb with 1 occurrences migrated to:  
  https://dl.bintray.com/big-data/generic/tensorflow_inception_graph.pb ([https](https://dl.bintray.com/big-data/generic/tensorflow_inception_graph.pb) result 302).
* [ ] http://dl.bintray.com/big-data/generic/vocab.csv with 2 occurrences migrated to:  
  https://dl.bintray.com/big-data/generic/vocab.csv ([https](https://dl.bintray.com/big-data/generic/vocab.csv) result 302).